### PR TITLE
Minor fixes

### DIFF
--- a/Google Fonts/test_gf_spec.py
+++ b/Google Fonts/test_gf_spec.py
@@ -21,7 +21,7 @@ PROJECT_FILES = {
     'contributors': 'CONTRIBUTORS.txt',
     'trademark': 'TRADEMARKS.md',
     'readme': 'README.md',
-    '.gitignore'
+    'gitignore': '.gitignore'
     }
 
 COMPULSORY_FOLDERS = [

--- a/Google Fonts/test_gf_spec.py
+++ b/Google Fonts/test_gf_spec.py
@@ -131,7 +131,7 @@ def check_license_url_string(family_license_url):
 
 def check_family_fstype(font_fstype):
     print('***Check fsType***')
-    if font_fstype == SETTINGS['fstype']:
+    if font_fstype in (SETTINGS['fstype'], str(SETTINGS['fstype'])):
         print('PASS: Family fsType matches %s\n' % SETTINGS['fstype'])
     else:
         print('ERROR: Family fsType does not match %s\n' % SETTINGS['fstype'])


### PR DESCRIPTION
Please see the fix in the commit [93fdd23 fstype is returned as a string, not number on my machine](https://github.com/m4rc1e/mf-glyphs-scripts/commit/93fdd23402984c106ec72d671d860215e583c824)

I'm not sure about this, I'd say `fstype` is rather always returned as a string, but, there must be a reason why you made it a number, right?