### PR TITLE
Added modified auto metric script that syncs all open fonts

### DIFF
--- a/Fixes/auto_metrics_all_fonts.py
+++ b/Fixes/auto_metrics_all_fonts.py
@@ -1,0 +1,55 @@
+#MenuTitle: Auto Vert Metrics All Fonts
+"""Warning: Do not use this for updating fonts
+
+Apply auto vertical metrics based on legacy 125% rule and Khaled.
+
+Glyphsapp by default, exports fonts vertical metrics as 120% of the upm. This
+script will export the vertical metrics at 125% and feature no clipping on
+MS applications.
+
+The overall aim is to avoid clipping and make the appearance consistent across
+all platforms.
+"""
+from fix_vmetrics_win_clipping import shortest_tallest_glyphs
+
+
+def main():
+    Glyphs.showMacroWindow()
+    new_win_desc = 0
+    new_win_asc = 0
+
+    for font in Glyphs.fonts:
+        new_desc, new_asc = shortest_tallest_glyphs(font)
+        if new_desc < new_win_desc:
+            new_win_desc = new_desc
+        if new_win_asc < new_asc:
+            new_win_asc = new_asc
+
+    for font in Glyphs.fonts:
+        upm_125 = font.upm * 1.25
+        for master in font.masters:
+            vert = master.customParameters
+
+            print 'Updating %s vertical metrics' % master.name
+            asc = int(upm_125 * 0.75)
+            desc = -int(upm_125 * 0.25)
+
+            vert['typoAscender'] = asc
+            vert['typoDescender'] = desc
+            vert['typoLineGap'] = 0
+
+            vert['winAscent'] = int(new_win_asc)
+            vert['winDescent'] = int(abs(new_win_desc))
+
+            vert['hheaAscender'] = asc
+            vert['hheaDescender'] = desc
+            vert['hheaLineGap'] = 0
+
+            print 'Enabling Use Typo Metrics'
+            font.customParameters['Use Typo Metrics'] = True
+
+    print 'Done. Updated all masters vertical metrics of all open fonts'
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
I made a modified version of the "auto metrics" script that first scans all open fonts, not just all masters of the current font. It then sets the vertical metrics for all open fonts.